### PR TITLE
int/unsigned int --> int16_t/uint16_t for ESP8266 support

### DIFF
--- a/SFE_BMP180.h
+++ b/SFE_BMP180.h
@@ -10,7 +10,8 @@
 	Forked from BMP085 library by M.Grusin
 
 	version 1.0 2013/09/20 initial version
-	
+	version 1.1 2018/02/25 int -> int16_t (ESP8266)
+
 	Our example code uses the "beerware" license. You can do anything
 	you like with this code. No really, anything. If you find it useful,
 	buy me a (root) beer someday.
@@ -33,7 +34,7 @@ class SFE_BMP180
 		char begin();
 			// call pressure.begin() to initialize BMP180 before use
 			// returns 1 if success, 0 if failure (bad component or I2C bus shorted?)
-		
+
 		char startTemperature(void);
 			// command BMP180 to start a temperature measurement
 			// returns (number of ms to wait) for success, 0 for fail
@@ -68,7 +69,7 @@ class SFE_BMP180
 
 		char getError(void);
 			// If any library command fails, you can retrieve an extended
-			// error code using this command. Errors are from the wire library: 
+			// error code using this command. Errors are from the wire library:
 			// 0 = Success
 			// 1 = Data too long to fit in transmit buffer
 			// 2 = Received NACK on transmit of address
@@ -76,14 +77,14 @@ class SFE_BMP180
 			// 4 = Other error
 
 	private:
-	
-		char readInt(char address, int &value);
+
+		char readInt(char address, int16_t &value);
 			// read an signed int (16 bits) from a BMP180 register
 			// address: BMP180 register address
 			// value: external signed int for returned value (16 bits)
 			// returns 1 for success, 0 for fail, with result in value
 
-		char readUInt(char address, unsigned int &value);
+		char readUInt(char address, uint16_t &value);
 			// read an unsigned int (16 bits) from a BMP180 register
 			// address: BMP180 register address
 			// value: external unsigned int for returned value (16 bits)
@@ -94,15 +95,15 @@ class SFE_BMP180
 			// values: array of char with register address in first location [0]
 			// length: number of bytes to read back
 			// returns 1 for success, 0 for fail, with read bytes in values[] array
-			
+
 		char writeBytes(unsigned char *values, char length);
 			// write a number of bytes to a BMP180 register (and consecutive subsequent registers)
 			// values: array of char with register address in first location [0]
 			// length: number of bytes to write
 			// returns 1 for success, 0 for fail
-			
-		int AC1,AC2,AC3,VB1,VB2,MB,MC,MD;
-		unsigned int AC4,AC5,AC6; 
+
+		int16_t AC1,AC2,AC3,VB1,VB2,MB,MC,MD;
+		uint16_t AC4,AC5,AC6;
 		double c5,c6,mc,md,x0,x1,x2,y0,y1,y2,p0,p1,p2;
 		char _error;
 };


### PR DESCRIPTION
Hi, just changed all int / unsigned int to specific int16_t and uint16_t. Now this lib also runs under ESP8266 correctly.