### PR TITLE
ESP32 compile error fix

### DIFF
--- a/SFE_BMP180.cpp
+++ b/SFE_BMP180.cpp
@@ -177,7 +177,7 @@ char SFE_BMP180::readBytes(unsigned char *values, char length)
 // values: external array to hold data. Put starting register in values[0].
 // length: number of bytes to read
 {
-	char x;
+	unsigned char x;
 
 	Wire.beginTransmission(BMP180_ADDR);
 	Wire.write(values[0]);
@@ -200,7 +200,7 @@ char SFE_BMP180::writeBytes(unsigned char *values, char length)
 // values: external array of data to write. Put starting register in values[0].
 // length: number of bytes to write
 {
-	char x;
+	//char x;
 
 	Wire.beginTransmission(BMP180_ADDR);
 	Wire.write(values,length);


### PR DESCRIPTION
Hi

Just a minor pull request so library compiles on ESp32 platfroms in Arduino IDE.
I tired to use this on ESP32 but it would not compile.
Gave following error:

`/home/gavin/Documents/Tech/arduino/libraries/SFE_BMP180/SFE_BMP180.cpp: In member function 'char SFE_BMP180::readBytes(unsigned char*, char)':
/home/gavin/Documents/Tech/arduino/libraries/SFE_BMP180/SFE_BMP180.cpp:190:12: error: array subscript has type 'char' [-Werror=char-subscripts]
    values[x] = Wire.read();
            ^
/home/gavin/Documents/Tech/arduino/libraries/SFE_BMP180/SFE_BMP180.cpp: In member function 'char SFE_BMP180::writeBytes(unsigned char*, char)':
/home/gavin/Documents/Tech/arduino/libraries/SFE_BMP180/SFE_BMP180.cpp:203:7: warning: unused variable 'x' [-Wunused-variable]
  char x;
       ^
cc1plus: some warnings being treated as errors`

By changing the char x to a unsigned char x in "readBytes" function fixed it. It now compiles on ESP32 boards.
I also re-tested it with arduino UNO and everything looks ok. 

Thanks!

